### PR TITLE
Generic solutions for PivotFinder

### DIFF
--- a/GAD 6 - Verbessertes Sortieren/tests/simplesort/CustomAssertion.java
+++ b/GAD 6 - Verbessertes Sortieren/tests/simplesort/CustomAssertion.java
@@ -1,0 +1,35 @@
+package tests.simplesort;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Arrays;
+
+public class CustomAssertion extends Assertions {
+
+    public static void assertEquals(int expected, int expected2, int actual) {
+        if ((expected != actual) && (expected2 != actual)) {
+            assertEquals(expected, actual, "Should be: " + expected + " or " + expected2 + " but was " + actual);
+        }
+    }
+
+    public static void assertEquals(int expected, int expected2, int expected3, int actual) {
+        if ((expected != actual) && (expected2 != actual) && (expected3 != actual)) {
+            assertEquals(expected, actual, "Should be: " + expected + ", " + expected2 + " or " + expected3 + " but was " + actual);
+        }
+    }
+
+    public static void assertArrayEquals(int[] expected, int[] expected2, int[] actual) {
+        if (!Arrays.equals(expected, actual) && !Arrays.equals(expected2, actual)) {
+            assertEquals(expected, actual, "Should be: " + Arrays.toString(expected) + " or " + Arrays.toString(expected2) +
+                    " but was " + Arrays.toString(actual));
+        }
+    }
+
+    public static void assertArrayEquals(int[] expected, int[] expected2, int[] expected3, int[] actual) {
+        if (!Arrays.equals(expected, actual) && !Arrays.equals(expected2, actual) && !Arrays.equals(expected3, actual)) {
+            assertEquals(expected, actual, "Should be: " + Arrays.toString(expected) + ", " + Arrays.toString(expected2) +
+                    " or " + Arrays.toString(expected3) + " but was " + Arrays.toString(actual));
+        }
+    }
+
+}

--- a/GAD 6 - Verbessertes Sortieren/tests/simplesort/PivotFinderTester.java
+++ b/GAD 6 - Verbessertes Sortieren/tests/simplesort/PivotFinderTester.java
@@ -8,13 +8,16 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+//import static org.junit.jupiter.api.Assertions.*;
+import static tests.simplesort.CustomAssertion.*;
 
 class PivotFinderTester {
 
     @BeforeEach
     void printLine() {
+
         System.out.println("-------------------------");
+
     }
 
     /**
@@ -508,8 +511,8 @@ class PivotFinderTester {
         int[] array;
 
         array = new int[] {69, 420};
-        assertEquals(0, PivotFinder.getMedianPivotFront(3).findPivot(array, 0, 1));
-        assertEquals(0, PivotFinder.getMedianPivotFront(5).findPivot(array, 0, 1));
+        assertEquals(0, 1, PivotFinder.getMedianPivotFront(3).findPivot(array, 0, 1));
+        assertEquals(0, 1, PivotFinder.getMedianPivotFront(5).findPivot(array, 0, 1));
         array = new int[] {352, -198, 88};
         assertEquals(2, PivotFinder.getMedianPivotFront(5).findPivot(array, 0, 2));
         array = new int[] {117, 357, -487, -153};
@@ -738,7 +741,7 @@ class PivotFinderTester {
         array = new int[] {425, -284, -45, 27};
         assertEquals(2, PivotFinder.getMedianPivotDistributed(3).findPivot(array, 1, 3));
         array = new int[] {-484, 36, -408, 240, -366};
-        assertEquals(4, PivotFinder.getMedianPivotDistributed(5).findPivot(array, 1, 4));
+        assertEquals(4, 1, PivotFinder.getMedianPivotDistributed(5).findPivot(array, 1, 4));
         array = new int[] {-180, 228, 272, 406, -313, 350};
         assertEquals(2, PivotFinder.getMedianPivotDistributed(3).findPivot(array, 2, 5));
         array = new int[] {-249, 352, -24, 110, 316, 150, 137};
@@ -746,7 +749,7 @@ class PivotFinderTester {
         array = new int[] {468, 402, -59, 15, 209, -148, -422, 464};
         assertEquals(5, PivotFinder.getMedianPivotDistributed(5).findPivot(array, 5, 7));
         array = new int[] {240, 285, -219, 25, -363, 299, 200, -69, 50};
-        assertEquals(8, PivotFinder.getMedianPivotDistributed(5).findPivot(array, 6, 8));
+        assertEquals(8, 6, PivotFinder.getMedianPivotDistributed(5).findPivot(array, 6, 8));
         array = new int[] {435, -269, 269, 297, 353, 49, -150, -194, 88, -363};
         assertEquals(7, PivotFinder.getMedianPivotDistributed(3).findPivot(array, 5, 9));
         array = new int[] {-421, 214, -72, -469, -412, -19, 483, -422, -400, -427, 385};
@@ -953,10 +956,10 @@ class PivotFinderTester {
     }
 
     /**
-        Beware: These tests are in some regards *stricter* than the Artemis tests. Good for finding exceptions and general edge cases regardless.
-        
-        Provided by the man, the myth, the legend: Ralg
-    */
+     Beware: These tests are in some regards *stricter* than the Artemis tests. Good for finding exceptions and general edge cases regardless.
+
+     Provided by the man, the myth, the legend: Ralg
+     */
     @Test
     void testAll() {
         System.out.println("Mid Pivot"+System.lineSeparator());
@@ -980,11 +983,11 @@ class PivotFinderTester {
     }
 
     /**
-        Beware: This test helper is in some regards *stricter* than the Artemis tests. Good for finding exceptions and general edge cases regardless.
-        maxArrayLength 30 is recommended for general testing, 3 for the small array tests.
-        
-        Provided by the man, the myth, the legend: Ralg
-    */
+     Beware: This test helper is in some regards *stricter* than the Artemis tests. Good for finding exceptions and general edge cases regardless.
+     maxArrayLength 30 is recommended for general testing, 3 for the small array tests.
+
+     Provided by the man, the myth, the legend: Ralg
+     */
     static void bigArraysTestHelper(PivotFinder f, int seed, int maxArrayLength) {
         Random ralg = new Random(seed);
         for (int i = 0; i < 10000; i++) {


### PR DESCRIPTION
**Link any issues if they have led to changes in the request**  


**Please describe the (sub-)exercises the tests are meant for**  
* GAD 6

**INFO**
I have 100% on Artemis and still fail some tests in the PivotFinders. I know that the tests say that they expect the first possible Pivot, but why not make it generic (without much effort).

My solution adds a new CustomAssertion class which extends Assertions and can be used as the Assertion class. But I've implemented more assertEquals with multiple possible solutions. So in the future, when someone with 100% runs the tests and has a different, working solution (let's say 4), he can just add " 4," behind the first solution.

This allows generic testing without changing all tests and very easy extensions in the future.

(If there's an easier way to do this, im very sorry, just close this)
