### PR TITLE
Quick fix for misleading message

### DIFF
--- a/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
+++ b/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
@@ -71,7 +71,7 @@ class TesterDualQuicksortResult implements Result {
         int pivotOne = endResult[indicesOfLog[1] + 1];
         int pivotTwo = endResult[indicesOfLog[3] + 1];
 
-        assertTrue(pivotOne <= pivotTwo, "Array: " + Arrays.toString(endResult) +
+        if (pivotOne > pivotTwo) fail("Array: " + Arrays.toString(endResult) +
                 "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
                 "\nThe second pivot is smaller than the first one");
 


### PR DESCRIPTION
**Link any issues if they have led to changes in the request**  


**Please describe the (sub-)exercises the tests are meant for**  
* GAD 6
* DualPivotQuicksortTester: Fix for misleading messages: Because "The second pivot is smaller than the first one ==> expected: <true> but was: <false>"  can be misleading it just says "The second pivot is smaller than the first one".
