### PR TITLE
Check if correct Pivot is used

### DIFF
--- a/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
+++ b/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
@@ -11,12 +11,11 @@ class TesterDualQuicksortResult implements Result {
     int[] numbersAtStart = null;
     int[] indicesOfLog = new int[6];
     int countThroughLog = 0;
+    DualPivotFinder pivotFinder;
 
     public TesterDualQuicksortResult(DualPivotFinder pivotFinder) {
         this.pivotFinder = pivotFinder;
     }
-
-    DualPivotFinder pivotFinder;
 
     @Override
     public void startSelectionsort(int[] array, int from, int to) {
@@ -82,31 +81,35 @@ class TesterDualQuicksortResult implements Result {
         int pivotTwo = endResult[indicesOfLog[3] + 1];
 
         if (!(valuePivotStartFirst == pivotOne && valuePivotStartSecond == pivotTwo) &&
-                !(valuePivotStartFirst == pivotTwo && valuePivotStartSecond == pivotOne))
-            fail("Array: " + Arrays.toString(endResult) +
-                    "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
+                !(valuePivotStartFirst == pivotTwo && valuePivotStartSecond == pivotOne)) {
+            fail("Array: " + Arrays.toString(endResult) + "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
                     "\nThe pivots of the pivot finder do not correspond to the log Pivots");
+        }
 
-        if (pivotOne > pivotTwo) fail("Array: " + Arrays.toString(endResult) +
-                "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
-                "\nThe second pivot is smaller than the first one");
+        if (pivotOne > pivotTwo) {
+            fail("Array: " + Arrays.toString(endResult) + "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
+                    "\nThe second pivot is smaller than the first one");
+        }
 
         for (int i = indicesOfLog[0]; i <= indicesOfLog[1]; i++) {
-            if (endResult[i] > pivotOne)
+            if (endResult[i] > pivotOne) {
                 fail("Array: " + Arrays.toString(endResult) + "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
                         "\nIn the first part is at index " + (indicesOfLog[0] + i) + " a number bigger than the first pivot");
+            }
         }
 
         for (int i = indicesOfLog[2]; i <= indicesOfLog[3]; i++) {
-            if (endResult[i] < pivotOne || endResult[i] > pivotTwo)
+            if (endResult[i] < pivotOne || endResult[i] > pivotTwo) {
                 fail("Array: " + Arrays.toString(endResult) + "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
                         "\nIn the second part is at index " + (indicesOfLog[2] + i) + " a number than shouldn't be there");
+            }
         }
 
         for (int i = indicesOfLog[4]; i <= indicesOfLog[5]; i++) {
-            if (endResult[i] < pivotTwo)
+            if (endResult[i] < pivotTwo) {
                 fail("Array: " + Arrays.toString(endResult) + "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
                         "\nIn the third part is at index " + (indicesOfLog[4] + i) + " a number smaller than the second pivot");
+            }
         }
     }
 }

--- a/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
+++ b/GAD 6 - Verbessertes Sortieren/tests/simplesort/TesterDualQuicksortResult.java
@@ -1,5 +1,6 @@
 package tests.simplesort;
 
+import gad.simplesort.DualPivotFinder;
 import gad.simplesort.Result;
 
 import java.util.Arrays;
@@ -7,9 +8,15 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TesterDualQuicksortResult implements Result {
-    int[] startResult = null;
+    int[] numbersAtStart = null;
     int[] indicesOfLog = new int[6];
     int countThroughLog = 0;
+
+    public TesterDualQuicksortResult(DualPivotFinder pivotFinder) {
+        this.pivotFinder = pivotFinder;
+    }
+
+    DualPivotFinder pivotFinder;
 
     @Override
     public void startSelectionsort(int[] array, int from, int to) {
@@ -28,7 +35,7 @@ class TesterDualQuicksortResult implements Result {
 
     @Override
     public void startDualPivotQuicksort(int[] array, int from, int to) {
-        startResult = Arrays.copyOfRange(array, from, to + 1);
+        numbersAtStart = Arrays.copyOf(array, array.length);
     }
 
     @Override
@@ -50,26 +57,35 @@ class TesterDualQuicksortResult implements Result {
     }
 
     private void analyseLogsOfDualPivot(int[] endResult) {
-        if (startResult == null || endResult == null) {
+        if (numbersAtStart == null || endResult == null) {
             throw new IllegalArgumentException("Array: " + Arrays.toString(endResult) + "\n" + "\nIn range: " + indicesOfLog[0] +
                     " to " + indicesOfLog[5] + "\n" + "\nLogged partial Arrays without logging startResult or endResult");
         }
 
-        Arrays.sort(startResult);
+        int[] numbersAtStartPartial = Arrays.copyOfRange(numbersAtStart, indicesOfLog[0], indicesOfLog[5] + 1);
+        Arrays.sort(numbersAtStartPartial);
         int[] copyEndResult = Arrays.copyOfRange(endResult, indicesOfLog[0], indicesOfLog[5] + 1);
         Arrays.sort(copyEndResult);
 
-        assertEquals(startResult.length, copyEndResult.length, "Array: " + Arrays.toString(endResult) + "\nIn range: "
+        assertEquals(numbersAtStartPartial.length, copyEndResult.length, "Array: " + Arrays.toString(endResult) + "\nIn range: "
                 + indicesOfLog[0] + " to " + indicesOfLog[5] + "\nThe arrays before and after the sort dont have the same length anymore, " +
                 "you probably changed the to or from pointer");
 
-
-        assertArrayEquals(copyEndResult, startResult, "Array: " + Arrays.toString(endResult) + "\nIn range: " +
+        assertArrayEquals(copyEndResult, numbersAtStartPartial, "Array: " + Arrays.toString(endResult) + "\nIn range: " +
                 indicesOfLog[0] + " to " + indicesOfLog[5] + "\nThe arrays before and after the sort have different numbers");
 
+        int[] pivots = pivotFinder.findPivot(numbersAtStart, indicesOfLog[0], indicesOfLog[5]);
+        int valuePivotStartFirst = numbersAtStart[pivots[0]];
+        int valuePivotStartSecond = numbersAtStart[pivots[1]];
 
         int pivotOne = endResult[indicesOfLog[1] + 1];
         int pivotTwo = endResult[indicesOfLog[3] + 1];
+
+        if (!(valuePivotStartFirst == pivotOne && valuePivotStartSecond == pivotTwo) &&
+                !(valuePivotStartFirst == pivotTwo && valuePivotStartSecond == pivotOne))
+            fail("Array: " + Arrays.toString(endResult) +
+                    "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +
+                    "\nThe pivots of the pivot finder do not correspond to the log Pivots");
 
         if (pivotOne > pivotTwo) fail("Array: " + Arrays.toString(endResult) +
                 "\nIn range: " + indicesOfLog[0] + " to " + indicesOfLog[5] +


### PR DESCRIPTION
**Shortly describe your proposed changes:**
Improvement to DualPivotQuickSort tests. They now additionally check if the used pivot corresponds to the pivots the DualPivotFinder returns. 
(I had a pull request earlier but somehow deleted other tests and had to clean up my fork before opening this again)

**Link any issues if they have led to changes in the request:**



**Note the (sub-)exercises the tests are meant for:**

* GAD 6
