### PR TITLE
Added yet another check for illegal arguments in key()

### DIFF
--- a/GAD 7 - Radixsort/tests/radix/RadixSortTester.java
+++ b/GAD 7 - Radixsort/tests/radix/RadixSortTester.java
@@ -274,6 +274,7 @@ public class RadixSortTester {
             assertThrows(IllegalArgumentException.class, () -> RadixSort.key(-10, 4));
             assertThrows(IllegalArgumentException.class, () -> RadixSort.key(-10, -69));
             assertThrows(IllegalArgumentException.class, () -> RadixSort.key(-69, -420));
+            assertThrows(IllegalArgumentException.class, () -> RadixSort.key(69, -42));
             assertEquals(6, RadixSort.key(6467677, 6));
             assertEquals(7, RadixSort.key(6701586, 5));
             assertEquals(6, RadixSort.key(1584166, 1));


### PR DESCRIPTION
**Shortly describe your proposed changes:**

Added another check for illegal arguments in `key(int, int)`

**Note the (sub-)exercises the tests are meant for:**

* GAD 7
